### PR TITLE
ARM: dts: blix-bx: fix property names for rotary-switch

### DIFF
--- a/arch/arm/boot/dts/imx6qdl-blix-bx.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-blix-bx.dtsi
@@ -139,8 +139,8 @@
 		/* linux,axis = <1>;*/ /* REL_Y */
 		/* rotary-encoder,relative-axis; */
 		rotary-encoder,noaxis;
-		rotary-encoder,codeCCW = <60>; /* KEY_F2 */
-		rotary-encoder,codeCW = <15>; /* KEY_TAB */
+		linux,code-ccw = <60>; /* KEY_F2 */
+		linux,code-cw = <15>; /* KEY_TAB */
 		rotary-encoder,half-period;
 	};
 


### PR DESCRIPTION
The property names for the rotary switch in the 4.17.x kernel
driver is different to the one of the 4.1.x driver.
Yet the .dtsi file has been copied over without changes.
Thus the driver did not find the property and used default
values for the key created key events.

This commit syncs the driver to the .dtsi file and makes
the driver read the intended values again.